### PR TITLE
Feat: Lesson17 (2. Create back and next arrow buttons for the slideshow)

### DIFF
--- a/lesson17/css/style.css
+++ b/lesson17/css/style.css
@@ -1,7 +1,7 @@
 .loading {
   position: fixed;
-  top: 0;
-  left: 0;
+  top: 45%;
+  left: 45%;
   z-index: 1;
 }
 
@@ -10,6 +10,42 @@
   visibility: hidden;
 }
 
-/* .is-show {
+.btn {
+  padding: 15px;
+  font-size: 20px;
+}
 
-} */
+.slideshow {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0; 
+  display: flex;
+  align-items: center;
+  margin: 0 auto;
+  width: 70%;
+}
+
+.slideshow__list {
+  position: relative;
+  width: 100%;
+  height: 300px;
+}
+.slideshow__img {
+  position: absolute;
+  padding: 10px;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 320px;
+  height: 240px;
+  margin: auto;
+  z-index: 0;
+  display: none;
+}
+
+.is-show {
+  display: block;
+}

--- a/lesson17/index.html
+++ b/lesson17/index.html
@@ -9,8 +9,8 @@
     <title>TerraceTechフロントエンドエンジニア養成所</title>
   </head>
   <body>
-    <div id="js-wrapper">
-      <ul id="js-slideshow"></ul>
+    <div id="js-slideshow" class="slideshow">
+      <ul id="js-img-list" class="slideshow__list"></ul>
     </div>
     <script src="/main.js"></script>
   </body>

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -115,9 +115,19 @@ const goBack = () => {
 const init = async () => {
   createLoader();
   loading();
-  const imgData = await fetcheImgData();
-  createListsOfImg(imgData);
-  createArrowBtnForSlideshow();
+  let imgData;
+  try {
+    imgData = await fetcheImgData();
+  } catch (e) {
+    console.error();
+  } finally {
+    console.log("処理が完了しました。");
+  }
+  if (imgData.length !== 0) {
+    createListsOfImg(imgData);
+    createArrowBtnForSlideshow();
+  } else {
+    slideshowWrap.textContent = "データがありません。"; 
+  }
 };
-
 init();

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -1,6 +1,6 @@
 const jsonUrl = "https://jsondata.okiba.me/v1/json/YbIZe211030061143";
-const wrapper = document.getElementById("js-wrapper");
-const ul = document.getElementById("js-slideshow");
+const wrapper = document.getElementById("js-slideshow");
+const ul = document.getElementById("js-img-list");
 const numOfSecond = 3;
 
 const createElementWithClassName = (element, name) => {
@@ -27,7 +27,7 @@ const loaded = () => {
   loader.classList.add("loaded");
 };
 
-const fetcheDataInSecond = (sec,jsonUrl) => {
+const fetcheDataInSecond = (sec, jsonUrl) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve(fetch(jsonUrl));
@@ -35,10 +35,9 @@ const fetcheDataInSecond = (sec,jsonUrl) => {
   });
 };
 
-
 const fetcheImgData = async () => {
   try {
-    const response = await fetcheDataInSecond(numOfSecond,jsonUrl);
+    const response = await fetcheDataInSecond(numOfSecond, jsonUrl);
     const json = await response.json();
     return json.images;
   } catch (error) {
@@ -49,17 +48,10 @@ const fetcheImgData = async () => {
   }
 };
 
-const init = async () => {
-  createLoader();
-  loading();
-  const imgData = await fetcheImgData();
-  createListsOfImg(imgData);
-};
-
 const createListsOfImg = (imgData) => {
   const fragment = document.createDocumentFragment();
-  imgData.forEach((imgVal,index) => {
-    const li = createElementWithClassName("li","slideshow-img");
+  imgData.forEach((imgVal, index) => {
+    const li = createElementWithClassName("li", "slideshow__img");
     const img = document.createElement("img");
     img.src = imgVal.src;
 
@@ -67,9 +59,65 @@ const createListsOfImg = (imgData) => {
     index === 0 && li.classList.add("is-show");
 
     fragment.appendChild(li).appendChild(img);
-  })
-ul.appendChild(fragment);
-}
+  });
+  ul.appendChild(fragment);
+};
+
+const createArrowBtnForSlideshow = () => {
+  createNextBtn();
+  createBackBtn();
+};
+
+const createNextBtn = () => {
+  const nextBtn = createElementWithClassName("button", "btn");
+  nextBtn.id = "js-next-btn";
+  nextBtn.textContent = ">";
+  ul.insertAdjacentElement("afterend", nextBtn);
+  nextBtn.addEventListener(
+    "click",
+    () => {
+      goNext();
+    },
+    false
+  );
+};
+
+const createBackBtn = () => {
+  const backBtn = createElementWithClassName("button", "btn");
+  backBtn.id = "js-back-btn";
+  backBtn.textContent = "<";
+  ul.insertAdjacentElement("beforebegin", backBtn);
+  backBtn.addEventListener(
+    "click",
+    () => {
+      goBack();
+    },
+    false
+  );
+};
+
+const goNext = () => {
+  const currentImg = document.querySelector(".is-show");
+  if (currentImg.nextElementSibling) {
+    currentImg.classList.remove("is-show");
+    currentImg.nextElementSibling.classList.add("is-show");
+  }
+};
+
+const goBack = () => {
+  const currentImg = document.querySelector(".is-show");
+  if (currentImg.previousElementSibling) {
+    currentImg.classList.remove("is-show");
+    currentImg.previousElementSibling.classList.add("is-show");
+  }
+};
+
+const init = async () => {
+  createLoader();
+  loading();
+  const imgData = await fetcheImgData();
+  createListsOfImg(imgData);
+  createArrowBtnForSlideshow();
+};
 
 init();
-

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -26,7 +26,6 @@ const loaded = () => {
   loader.classList.add("loaded");
 };
 
-const numOfSecond = 3000;
 const fetcheDataInSecond = (sec, jsonUrl) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
@@ -36,6 +35,7 @@ const fetcheDataInSecond = (sec, jsonUrl) => {
 };
 
 const fetcheImgData = async () => {
+  const numOfSecond = 3000;
   try {
     const response = await fetcheDataInSecond(numOfSecond, jsonUrl);
     const json = await response.json();

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -1,7 +1,6 @@
 const jsonUrl = "https://jsondata.okiba.me/v1/json/YbIZe211030061143";
 const slideshowWrap = document.getElementById("js-slideshow");
 const ul = document.getElementById("js-img-list");
-const numOfSecond = 3;
 
 const createElementWithClassName = (element, name) => {
   const createdElement = document.createElement(element);
@@ -27,11 +26,12 @@ const loaded = () => {
   loader.classList.add("loaded");
 };
 
+const numOfSecond = 3000;
 const fetcheDataInSecond = (sec, jsonUrl) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve(fetch(jsonUrl));
-    }, sec * 1000);
+    }, sec);
   });
 };
 

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -14,7 +14,7 @@ const createLoader = () => {
   const loaderImage = document.createElement("img");
   loader.id = "js-loader";
   loaderImage.src = "img/loading-circle.gif";
-  wrapper.appendChild(loader).appendChild(loaderImage);
+  slideshowWrap.appendChild(loader).appendChild(loaderImage);
 };
 
 const loading = () => {
@@ -41,7 +41,7 @@ const fetcheImgData = async () => {
     const json = await response.json();
     return json.images;
   } catch (error) {
-    wrapper.textContent = "データの取得ができませんでした。";
+    slideshowWrap.textContent = "データの取得ができませんでした。";
     console.error(error);
   } finally {
     loaded();

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -76,7 +76,7 @@ const createNextBtn = () => {
   nextBtn.addEventListener(
     "click",
     () => {
-      goNext();
+      imageSwitchButton("nextElementSibling");
     },
     false
   );
@@ -90,25 +90,17 @@ const createBackBtn = () => {
   backBtn.addEventListener(
     "click",
     () => {
-      goBack();
+      imageSwitchButton("previousElementSibling");
     },
     false
   );
 };
 
-const goNext = () => {
+const imageSwitchButton = (SwitchDirection) => {
   const currentImg = document.querySelector(".is-show");
-  if (currentImg.nextElementSibling) {
+  if (currentImg[SwitchDirection]) {
     currentImg.classList.remove("is-show");
-    currentImg.nextElementSibling.classList.add("is-show");
-  }
-};
-
-const goBack = () => {
-  const currentImg = document.querySelector(".is-show");
-  if (currentImg.previousElementSibling) {
-    currentImg.classList.remove("is-show");
-    currentImg.previousElementSibling.classList.add("is-show");
+    currentImg[SwitchDirection].classList.add("is-show");
   }
 };
 

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -1,5 +1,5 @@
 const jsonUrl = "https://jsondata.okiba.me/v1/json/YbIZe211030061143";
-const wrapper = document.getElementById("js-slideshow");
+const slideshowWrap = document.getElementById("js-slideshow");
 const ul = document.getElementById("js-img-list");
 const numOfSecond = 3;
 

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -111,7 +111,7 @@ const init = async () => {
   try {
     imgData = await fetcheImgData();
   } catch (e) {
-    console.error();
+    console.error(e);
   } finally {
     console.log("処理が完了しました。");
   }


### PR DESCRIPTION
# [Lesson17](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#%E3%82%B9%E3%83%A9%E3%82%A4%E3%83%89%E3%82%B7%E3%83%A7%E3%83%BC%E4%BD%9C%E6%88%90)
```
仕様
1.画面遷移してから3秒後に解決されるPromiseが返すオブジェクトを元にimgタグを5つつくる。

2.それぞれは.z-indexで重ねた状態。矢印画像をクリックを押すとスライド画像が変わる

3.5枚中何枚目かを表示して、5/5の場合Nextの矢印はdisabledにする。1/5枚の時はBackボタンはdisabledにする
```
## [CodeSandbox](https://codesandbox.io/s/lesson17-create-arrow-tur59?file=/main.js)
Last commit:[ecbab45](https://github.com/yuka830/js-lessons/pull/21/commits/ecbab458aa3e64b6f3b06b6c1d73765bf802aee8)

This time I implemented no.2 in the above specification lists.
Implemented next and back buttons using `nextElementSibling` and `previousElementSibling` property.

I made a mistake and included multiple fixes in this commit. I'm sorry about that.

■Change some name
Id
   `js-wrapper` → `js-slideshow`
   `js-slideshow` → `js-img-list`
Class name
   `slideshow-img` → `slideshow__img`