### PR TITLE
Feat: Lesson17 (3. Create arrow buttons with disable switch function and the number pagination)

### DIFF
--- a/lesson17/css/style.css
+++ b/lesson17/css/style.css
@@ -1,6 +1,5 @@
 .loading {
   position: fixed;
-  top: 45%;
   left: 45%;
   z-index: 1;
 }
@@ -16,11 +15,6 @@
 }
 
 .slideshow {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0; 
   display: flex;
   align-items: center;
   margin: 0 auto;
@@ -48,4 +42,9 @@
 
 .is-show {
   display: block;
+}
+
+.number-pagination {
+  text-align: center;
+  font-size: 20px;
 }

--- a/lesson17/css/style.css
+++ b/lesson17/css/style.css
@@ -21,11 +21,18 @@
   width: 70%;
 }
 
+@media screen and (max-width: 769px) {
+  .slideshow {
+    width: 100%;
+  }
+}
+
 .slideshow__list {
   position: relative;
   width: 100%;
   height: 300px;
 }
+
 .slideshow__img {
   position: absolute;
   padding: 10px;

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -77,7 +77,7 @@ const createNextBtn = () => {
   nextBtn.addEventListener(
     "click",
     () => {
-      imageSwitchButton("nextElementSibling");
+      switchImg("nextElementSibling");
       switchDisableForBtn();
       getCurrentPageNum();
     },
@@ -94,7 +94,7 @@ const createBackBtn = () => {
   backBtn.addEventListener(
     "click",
     () => {
-      imageSwitchButton("previousElementSibling");
+      switchImg("previousElementSibling");
       switchDisableForBtn();
       getCurrentPageNum();
     },
@@ -102,7 +102,7 @@ const createBackBtn = () => {
   );
 };
 
-const  imageSwitchButton = (SwitchDirection) => {
+const  switchImg = (SwitchDirection) => {
   const currentImg = document.querySelector(".is-show");
   if (currentImg[SwitchDirection]) {
     currentImg.classList.remove("is-show");

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -1,6 +1,7 @@
 const jsonUrl = "https://jsondata.okiba.me/v1/json/YbIZe211030061143";
 const slideshowWrap = document.getElementById("js-slideshow");
 const ul = document.getElementById("js-img-list");
+let imgArray = [];
 
 const createElementWithClassName = (element, name) => {
   const createdElement = document.createElement(element);
@@ -77,6 +78,8 @@ const createNextBtn = () => {
     "click",
     () => {
       imageSwitchButton("nextElementSibling");
+      switchDisableForBtn();
+      getCurrentPageNum();
     },
     false
   );
@@ -86,22 +89,65 @@ const createBackBtn = () => {
   const backBtn = createElementWithClassName("button", "btn");
   backBtn.id = "js-back-btn";
   backBtn.textContent = "<";
+  backBtn.disabled = true;
   ul.insertAdjacentElement("beforebegin", backBtn);
   backBtn.addEventListener(
     "click",
     () => {
       imageSwitchButton("previousElementSibling");
+      switchDisableForBtn();
+      getCurrentPageNum();
     },
     false
   );
 };
 
-const imageSwitchButton = (SwitchDirection) => {
+const  imageSwitchButton = (SwitchDirection) => {
   const currentImg = document.querySelector(".is-show");
   if (currentImg[SwitchDirection]) {
     currentImg.classList.remove("is-show");
     currentImg[SwitchDirection].classList.add("is-show");
   }
+};
+
+const createArrayOfImgLists = () => {
+  const images = document.querySelectorAll(".slideshow__img");
+  const arrayOfImg = Array.from(images);
+  return (imgArray = arrayOfImg);
+};
+
+const getCurrentImgIndex = () => {
+  const isShowImg = document.querySelector(".is-show");
+  const currentImgIndex = imgArray.indexOf(isShowImg);
+  return currentImgIndex;
+};
+
+const switchDisableForBtn = () => {
+  const nextBtn = document.getElementById("js-next-btn");
+  const backBtn = document.getElementById("js-back-btn");
+
+  if (getCurrentImgIndex() === 0) {
+    backBtn.disabled = true;
+  } else {
+    backBtn.disabled = false;
+  }
+
+  if (getCurrentImgIndex() === imgArray.length - 1) {
+    nextBtn.disabled = true;
+  } else {
+    nextBtn.disabled = false;
+  }
+};
+
+const createPagination = () => {
+  const pagination = createElementWithClassName("p", "number-pagination");
+  slideshowWrap.insertAdjacentElement("afterend", pagination);
+  getCurrentPageNum();
+};
+
+const getCurrentPageNum = () => {
+  const pagination = document.querySelector(".number-pagination");
+  pagination.textContent = `${getCurrentImgIndex() + 1}/${imgArray.length}`;
 };
 
 const init = async () => {
@@ -117,9 +163,11 @@ const init = async () => {
   }
   if (imgData.length !== 0) {
     createListsOfImg(imgData);
+    createArrayOfImgLists();
     createArrowBtnForSlideshow();
+    createPagination();
   } else {
-    slideshowWrap.textContent = "データがありません。"; 
+    slideshowWrap.textContent = "データがありません。";
   }
 };
 init();

--- a/lesson17/main.js
+++ b/lesson17/main.js
@@ -41,9 +41,9 @@ const fetcheImgData = async () => {
     const response = await fetcheDataInSecond(numOfSecond, jsonUrl);
     const json = await response.json();
     return json.images;
-  } catch (error) {
+  } catch (e) {
     slideshowWrap.textContent = "データの取得ができませんでした。";
-    console.error(error);
+    console.error(e);
   } finally {
     loaded();
   }


### PR DESCRIPTION
# [Lesson17](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#%E3%82%B9%E3%83%A9%E3%82%A4%E3%83%89%E3%82%B7%E3%83%A7%E3%83%BC%E4%BD%9C%E6%88%90)
```
仕様
1.画面遷移してから3秒後に解決されるPromiseが返すオブジェクトを元にimgタグを5つつくる。

2.それぞれは.z-indexで重ねた状態。矢印画像をクリックを押すとスライド画像が変わる

3.5枚中何枚目かを表示して、5/5の場合Nextの矢印はdisabledにする。1/5枚の時はBackボタンはdisabledにする
```
## [CodeSandbox](https://codesandbox.io/s/lesson17-create-arrow-buttons-with-disable-switch-function-and-the-number-pagination-6iz4k?file=/main.js)
Last commit: [043aaca](https://github.com/yuka830/js-lessons/pull/22/commits/043aacadbd08cfb4ff046f8997c18c4d776b4e23)

This time I implemented no.3 in the above specification lists.
I implemented disable switch function and number pagination using index and array.length of images.