### PR TITLE
Feat: Lesson18 (1. Create the dot pagination)

### DIFF
--- a/lesson18/css/style.css
+++ b/lesson18/css/style.css
@@ -18,13 +18,7 @@
   display: flex;
   align-items: center;
   margin: 0 auto;
-  width: 70%;
-}
-
-@media screen and (max-width: 769px) {
-  .slideshow {
-    width: 100%;
-  }
+  width: 500px;
 }
 
 .slideshow__list {
@@ -54,4 +48,24 @@
 .number-pagination {
   text-align: center;
   font-size: 20px;
+  margin-top: 10px;
+}
+
+.dot-pagination {
+  width: 150px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-around;
+}
+
+.dot {
+  width: 15px;
+  height: 15px;
+  border: 2px solid #8d8b8b;
+  border-radius: 50%;
+  background-color: #9fd5eb;
+}
+
+.is-active {
+  background-color: #25a5d8;
 }

--- a/lesson18/css/style.css
+++ b/lesson18/css/style.css
@@ -51,14 +51,14 @@
   margin-top: 10px;
 }
 
-.dot-pagination {
+.indicators {
   width: 150px;
   margin: 0 auto;
   display: flex;
   justify-content: space-around;
 }
 
-.dot {
+.indicator {
   width: 15px;
   height: 15px;
   border: 2px solid #8d8b8b;

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -114,10 +114,10 @@ const switchImgForBtn = (switchDirection) => {
 };
 
 const changeIndicator = (switchDirection) => {
-  const currentDot = document.querySelector(".is-active");
-  if (currentDot[switchDirection]) {
-    currentDot.classList.remove("is-active");
-    currentDot[switchDirection].classList.add("is-active");
+  const currentIndicator = document.querySelector(".is-active");
+  if (currentIndicator[switchDirection]) {
+    currentIndicator.classList.remove("is-active");
+    currentIndicator[switchDirection].classList.add("is-active");
   }
 };
 
@@ -161,45 +161,45 @@ const getCurrentPageNum = () => {
   pagination.textContent = `${getCurrentImgIndex() + 1}/${images.length}`;
 };
 
-const createDotPagination = () => {
-  const pagination = createElementWithClassName("div", "dot-pagination");
+const createIndicator = () => {
+  const pagination = createElementWithClassName("div", "indicators");
   const fragment = document.createDocumentFragment();
   for (let i = 0; i < images.length; i++) {
-    const dot = createElementWithClassName("sapn", "dot");
+    const indicator = createElementWithClassName("sapn", "indicator");
     //最初のインデックスをアクティブにする
-    i === 0 && dot.classList.add("is-active");
-    dot.addEventListener(
+    i === 0 && indicator.classList.add("is-active");
+    indicator.addEventListener(
       "click",
       (e) => {
-        clickDotEvents(e, i);
+        clickIndicatorEvents(e, i);
       },
       false
     );
-    fragment.appendChild(dot);
+    fragment.appendChild(indicator);
   }
   pagination.appendChild(fragment);
   slideshowWrap.insertAdjacentElement("afterend", pagination);
 };
 
-const clickDotEvents = (e, i) => {
-  switchDot(e);
-  switchImgForDot(i);
+const clickIndicatorEvents = (e, i) => {
+  switchActiveIndicator(e);
+  switchImgForIndicator(i);
   switchDisableForBtn();
   getCurrentPageNum();
 };
 
-const switchDot = (e) => {
-  const activeDot = document.querySelector(".is-active");
-  const targetDot = e.target;
-  activeDot.classList.remove("is-active");
-  targetDot.classList.add("is-active");
+const switchActiveIndicator = (e) => {
+  const activeIndicator = document.querySelector(".is-active");
+  const targetIndicator = e.target;
+  activeIndicator.classList.remove("is-active");
+  targetIndicator.classList.add("is-active");
 };
 
-const switchImgForDot = (index) => {
+const switchImgForIndicator = (index) => {
   const currentImg = document.querySelector(".is-show");
-  const indexOfTargetDot = index;
+  const indexOfTargetIndicator = index;
   currentImg.classList.remove("is-show");
-  images[indexOfTargetDot].classList.add("is-show");
+  images[indexOfTargetIndicator].classList.add("is-show");
 };
 
 const init = async () => {
@@ -218,7 +218,7 @@ const init = async () => {
     createArrayOfImgLists();
     createArrowBtnForSlideshow();
     createNumPagination();
-    createDotPagination();
+    createIndicator();
   } else {
     slideshowWrap.textContent = "データがありません。";
   }

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -197,9 +197,13 @@ const switchImgForIndicator = (e) => {
   const targetIndicator = e.target;
   const indexOfTargetIndicator =
     createArrayOfIndicators().indexOf(targetIndicator);
-  if(images[indexOfTargetIndicator]){
+    //子要素indicatorをクリックしたらその要素をアクティブにし、親要素をクリックした場合はなにもしない
+  const isClickedTargetElement = (index) => index !== -1;
+  if (isClickedTargetElement(indexOfTargetIndicator)) {
     currentImg.classList.remove("is-show");
     images[indexOfTargetIndicator].classList.add("is-show");
+  } else {
+    return;
   }
 };
 

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -9,7 +9,7 @@ const createElementWithClassName = (element, name) => {
   return createdElement;
 };
 
-const createLoader = () => {
+const renderLoader = () => {
   const loader = document.createElement("div");
   const loaderImage = document.createElement("img");
   loader.id = "js-loader";
@@ -50,7 +50,7 @@ const fetcheImgData = async () => {
   }
 };
 
-const createListsOfImg = (imgData) => {
+const renderListsOfImg = (imgData) => {
   const fragment = document.createDocumentFragment();
   imgData.forEach((imgVal, index) => {
     const li = createElementWithClassName("li", "slideshow__img");
@@ -65,21 +65,21 @@ const createListsOfImg = (imgData) => {
   ul.appendChild(fragment);
 };
 
-const createArrowBtnForSlideshow = () => {
-  createNextBtn();
+const renderArrowBtnForSlideshow = () => {
+  renderNextBtn();
   addEventToBtn("nextElementSibling", "js-next-btn");
-  createBackBtn();
+  renderBackBtn();
   addEventToBtn("previousElementSibling", "js-back-btn");
 };
 
-const createNextBtn = () => {
+const renderNextBtn = () => {
   const nextBtn = createElementWithClassName("button", "btn");
   nextBtn.id = "js-next-btn";
   nextBtn.textContent = ">";
   ul.insertAdjacentElement("afterend", nextBtn);
 };
 
-const createBackBtn = () => {
+const renderBackBtn = () => {
   const backBtn = createElementWithClassName("button", "btn");
   backBtn.id = "js-back-btn";
   backBtn.textContent = "<";
@@ -144,7 +144,7 @@ const switchDisableForBtn = () => {
   }
 };
 
-const createNumPagination = () => {
+const renderNumPagination = () => {
   const pagination = createElementWithClassName("p", "number-pagination");
   slideshowWrap.insertAdjacentElement("afterend", pagination);
   getCurrentPageNum();
@@ -155,12 +155,12 @@ const getCurrentPageNum = () => {
   pagination.textContent = `${getCurrentImgIndex() + 1}/${images.length}`;
 };
 
-const createIndicatorForSlideshow = () => {
-  createIndicator();
+const renderIndicatorForSlideshow = () => {
+  renderIndicator();
   addEventToIndicator();
 };
 
-const createIndicator = () => {
+const renderIndicator = () => {
   const pagination = createElementWithClassName("div", "indicators");
   const fragment = document.createDocumentFragment();
   for (let i = 0; i < images.length; i++) {
@@ -208,7 +208,7 @@ const createArrayOfIndicators = () => {
 };
 
 const init = async () => {
-  createLoader();
+  renderLoader();
   loading();
   let imgData;
   try {
@@ -219,11 +219,11 @@ const init = async () => {
     console.log("処理が完了しました。");
   }
   if (imgData.length !== 0) {
-    createListsOfImg(imgData);
+    renderListsOfImg(imgData);
     createArrayOfImgLists();
-    createArrowBtnForSlideshow();
-    createNumPagination();
-    createIndicatorForSlideshow();
+    renderArrowBtnForSlideshow();
+    renderNumPagination();
+    renderIndicatorForSlideshow();
   } else {
     slideshowWrap.textContent = "データがありません。";
   }

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -77,7 +77,7 @@ const createNextBtn = () => {
   nextBtn.addEventListener(
     "click",
     () => {
-      clickEvents("nextElementSibling");
+      clickBtnEvents("nextElementSibling");
     },
     false
   );
@@ -92,13 +92,13 @@ const createBackBtn = () => {
   backBtn.addEventListener(
     "click",
     () => {
-      clickEvents("previousElementSibling");
+      clickBtnEvents("previousElementSibling");
     },
     false
   );
 };
 
-const clickEvents = (SwitchDirection) => {
+const clickBtnEvents = (SwitchDirection) => {
   switchImgForBtn([SwitchDirection]);
   switchDotForBtn([SwitchDirection]);
   switchDisableForBtn();

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -77,9 +77,7 @@ const createNextBtn = () => {
   nextBtn.addEventListener(
     "click",
     () => {
-      switchImg("nextElementSibling");
-      switchDisableForBtn();
-      getCurrentPageNum();
+      clickEvents("nextElementSibling");
     },
     false
   );
@@ -94,19 +92,32 @@ const createBackBtn = () => {
   backBtn.addEventListener(
     "click",
     () => {
-      switchImg("previousElementSibling");
-      switchDisableForBtn();
-      getCurrentPageNum();
+      clickEvents("previousElementSibling");
     },
     false
   );
 };
 
-const  switchImg = (SwitchDirection) => {
+const clickEvents = (SwitchDirection) => {
+  switchImgForbtn([SwitchDirection]);
+  switchDotForbtn([SwitchDirection]);
+  switchDisableForBtn();
+  getCurrentPageNum();
+};
+
+const switchImgForbtn = (SwitchDirection) => {
   const currentImg = document.querySelector(".is-show");
   if (currentImg[SwitchDirection]) {
     currentImg.classList.remove("is-show");
     currentImg[SwitchDirection].classList.add("is-show");
+  }
+};
+
+const switchDotForbtn = (SwitchDirection) => {
+  const currentDot = document.querySelector(".is-active");
+  if (currentDot[SwitchDirection]) {
+    currentDot.classList.remove("is-active");
+    currentDot[SwitchDirection].classList.add("is-active");
   }
 };
 
@@ -139,7 +150,7 @@ const switchDisableForBtn = () => {
   }
 };
 
-const createPagination = () => {
+const createNumPagination = () => {
   const pagination = createElementWithClassName("p", "number-pagination");
   slideshowWrap.insertAdjacentElement("afterend", pagination);
   getCurrentPageNum();
@@ -148,6 +159,43 @@ const createPagination = () => {
 const getCurrentPageNum = () => {
   const pagination = document.querySelector(".number-pagination");
   pagination.textContent = `${getCurrentImgIndex() + 1}/${imgArray.length}`;
+};
+
+const createDotPagination = () => {
+  const pagination = createElementWithClassName("div", "dot-pagination");
+  const fragment = document.createDocumentFragment();
+  for (let i = 0; i < imgArray.length; i++) {
+    const dot = createElementWithClassName("sapn", "dot");
+    //最初のインデックスをアクティブにする
+    i === 0 && dot.classList.add("is-active");
+    dot.addEventListener(
+      "click",
+      (e) => {
+        switchDot(e);
+        switchImgForDot(i);
+        switchDisableForBtn();
+        getCurrentPageNum();
+      },
+      false
+    );
+    fragment.appendChild(dot);
+  }
+  pagination.appendChild(fragment);
+  slideshowWrap.insertAdjacentElement("afterend", pagination);
+};
+
+const switchDot = (e) => {
+  const activeDot = document.querySelector(".is-active");
+  const targetDot = e.target;
+  activeDot.classList.remove("is-active");
+  targetDot.classList.add("is-active");
+};
+
+const switchImgForDot = (index) => {
+  const currentImg = document.querySelector(".is-show");
+  const indexOfTargetDot = index;
+  currentImg.classList.remove("is-show");
+  imgArray[indexOfTargetDot].classList.add("is-show");
 };
 
 const init = async () => {
@@ -165,7 +213,8 @@ const init = async () => {
     createListsOfImg(imgData);
     createArrayOfImgLists();
     createArrowBtnForSlideshow();
-    createPagination();
+    createNumPagination();
+    createDotPagination();
   } else {
     slideshowWrap.textContent = "データがありません。";
   }

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -99,13 +99,13 @@ const createBackBtn = () => {
 };
 
 const clickEvents = (SwitchDirection) => {
-  switchImgForbtn([SwitchDirection]);
-  switchDotForbtn([SwitchDirection]);
+  switchImgForBtn([SwitchDirection]);
+  switchDotForBtn([SwitchDirection]);
   switchDisableForBtn();
   getCurrentPageNum();
 };
 
-const switchImgForbtn = (SwitchDirection) => {
+const switchImgForBtn = (SwitchDirection) => {
   const currentImg = document.querySelector(".is-show");
   if (currentImg[SwitchDirection]) {
     currentImg.classList.remove("is-show");
@@ -113,7 +113,7 @@ const switchImgForbtn = (SwitchDirection) => {
   }
 };
 
-const switchDotForbtn = (SwitchDirection) => {
+const switchDotForBtn = (SwitchDirection) => {
   const currentDot = document.querySelector(".is-active");
   if (currentDot[SwitchDirection]) {
     currentDot.classList.remove("is-active");

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -162,6 +162,11 @@ const getCurrentPageNum = () => {
   pagination.textContent = `${getCurrentImgIndex() + 1}/${images.length}`;
 };
 
+const createIndicatorForSlideshow = () => {
+  createIndicator();
+  addEventToIndicator();
+};
+
 const createIndicator = () => {
   const pagination = createElementWithClassName("div", "indicators");
   const fragment = document.createDocumentFragment();
@@ -169,22 +174,26 @@ const createIndicator = () => {
     const indicator = createElementWithClassName("sapn", "indicator");
     //最初のインデックスをアクティブにする
     i === 0 && indicator.classList.add("is-active");
-    indicator.addEventListener(
-      "click",
-      (e) => {
-        clickIndicatorEvents(e, i);
-      },
-      false
-    );
     fragment.appendChild(indicator);
   }
   pagination.appendChild(fragment);
   slideshowWrap.insertAdjacentElement("afterend", pagination);
 };
 
-const clickIndicatorEvents = (e, i) => {
+const addEventToIndicator = () => {
+  const indicator = document.querySelector(".indicators");
+  indicator.addEventListener(
+    "click",
+    (e) => {
+      clickIndicatorEvents(e);
+    },
+    false
+  );
+};
+
+const clickIndicatorEvents = (e) => {
   switchActiveIndicator(e);
-  switchImgForIndicator(i);
+  switchImgForIndicator(e);
   switchDisableForBtn();
   getCurrentPageNum();
 };
@@ -196,11 +205,20 @@ const switchActiveIndicator = (e) => {
   targetIndicator.classList.add("is-active");
 };
 
-const switchImgForIndicator = (index) => {
+const switchImgForIndicator = (e) => {
   const currentImg = document.querySelector(".is-show");
-  const indexOfTargetIndicator = index;
+  const targetIndicator = e.target;
+  const indexOfTargetIndicator = createArrayOfIndicators().indexOf(
+    targetIndicator
+  );
   currentImg.classList.remove("is-show");
   images[indexOfTargetIndicator].classList.add("is-show");
+};
+
+const createArrayOfIndicators = () => {
+  const indicator = document.querySelectorAll(".indicator");
+  const arrayOfIndicator = Array.from(indicator);
+  return arrayOfIndicator;
 };
 
 const init = async () => {
@@ -219,9 +237,8 @@ const init = async () => {
     createArrayOfImgLists();
     createArrowBtnForSlideshow();
     createNumPagination();
-    createIndicator();
+    createIndicatorForSlideshow();
   } else {
-    slideshowWrap.style.margin = 0;
     slideshowWrap.textContent = "データがありません。";
   }
 };

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -67,7 +67,9 @@ const createListsOfImg = (imgData) => {
 
 const createArrowBtnForSlideshow = () => {
   createNextBtn();
+  addEventToBtn("nextElementSibling", "js-next-btn");
   createBackBtn();
+  addEventToBtn("previousElementSibling", "js-back-btn");
 };
 
 const createNextBtn = () => {
@@ -75,13 +77,6 @@ const createNextBtn = () => {
   nextBtn.id = "js-next-btn";
   nextBtn.textContent = ">";
   ul.insertAdjacentElement("afterend", nextBtn);
-  nextBtn.addEventListener(
-    "click",
-    () => {
-      clickBtnEvents("nextElementSibling");
-    },
-    false
-  );
 };
 
 const createBackBtn = () => {
@@ -90,13 +85,11 @@ const createBackBtn = () => {
   backBtn.textContent = "<";
   backBtn.disabled = true;
   ul.insertAdjacentElement("beforebegin", backBtn);
-  backBtn.addEventListener(
-    "click",
-    () => {
-      clickBtnEvents("previousElementSibling");
-    },
-    false
-  );
+};
+
+const addEventToBtn = (direction, id) => {
+  const btn = document.getElementById(id);
+  btn.addEventListener("click", () => clickBtnEvents(direction), false);
 };
 
 const clickBtnEvents = (switchDirection) => {

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -164,7 +164,7 @@ const renderIndicator = () => {
   const pagination = createElementWithClassName("div", "indicators");
   const fragment = document.createDocumentFragment();
   for (let i = 0; i < images.length; i++) {
-    const indicator = createElementWithClassName("sapn", "indicator");
+    const indicator = createElementWithClassName("span", "indicator");
     //最初のインデックスをアクティブにする
     i === 0 && indicator.classList.add("is-active");
     fragment.appendChild(indicator);
@@ -197,8 +197,10 @@ const switchImgForIndicator = (e) => {
   const targetIndicator = e.target;
   const indexOfTargetIndicator =
     createArrayOfIndicators().indexOf(targetIndicator);
-  currentImg.classList.remove("is-show");
-  images[indexOfTargetIndicator].classList.add("is-show");
+  if(images[indexOfTargetIndicator]){
+    currentImg.classList.remove("is-show");
+    images[indexOfTargetIndicator].classList.add("is-show");
+  }
 };
 
 const createArrayOfIndicators = () => {

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -182,13 +182,7 @@ const createIndicator = () => {
 
 const addEventToIndicator = () => {
   const indicator = document.querySelector(".indicators");
-  indicator.addEventListener(
-    "click",
-    (e) => {
-      clickIndicatorEvents(e);
-    },
-    false
-  );
+  indicator.addEventListener("click", (e) => clickIndicatorEvents(e), false);
 };
 
 const clickIndicatorEvents = (e) => {
@@ -208,9 +202,8 @@ const switchActiveIndicator = (e) => {
 const switchImgForIndicator = (e) => {
   const currentImg = document.querySelector(".is-show");
   const targetIndicator = e.target;
-  const indexOfTargetIndicator = createArrayOfIndicators().indexOf(
-    targetIndicator
-  );
+  const indexOfTargetIndicator =
+    createArrayOfIndicators().indexOf(targetIndicator);
   currentImg.classList.remove("is-show");
   images[indexOfTargetIndicator].classList.add("is-show");
 };

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -98,26 +98,26 @@ const createBackBtn = () => {
   );
 };
 
-const clickBtnEvents = (SwitchDirection) => {
-  switchImgForBtn([SwitchDirection]);
-  switchDotForBtn([SwitchDirection]);
+const clickBtnEvents = (switchDirection) => {
+  switchImgForBtn(switchDirection);
+  switchDotForBtn(switchDirection);
   switchDisableForBtn();
   getCurrentPageNum();
 };
 
-const switchImgForBtn = (SwitchDirection) => {
+const switchImgForBtn = (switchDirection) => {
   const currentImg = document.querySelector(".is-show");
-  if (currentImg[SwitchDirection]) {
+  if (currentImg[switchDirection]) {
     currentImg.classList.remove("is-show");
-    currentImg[SwitchDirection].classList.add("is-show");
+    currentImg[switchDirection].classList.add("is-show");
   }
 };
 
-const switchDotForBtn = (SwitchDirection) => {
+const switchDotForBtn = (switchDirection) => {
   const currentDot = document.querySelector(".is-active");
-  if (currentDot[SwitchDirection]) {
+  if (currentDot[switchDirection]) {
     currentDot.classList.remove("is-active");
-    currentDot[SwitchDirection].classList.add("is-active");
+    currentDot[switchDirection].classList.add("is-active");
   }
 };
 

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -100,7 +100,7 @@ const createBackBtn = () => {
 
 const clickBtnEvents = (switchDirection) => {
   switchImgForBtn(switchDirection);
-  switchDotForBtn(switchDirection);
+  changeIndicator(switchDirection);
   switchDisableForBtn();
   getCurrentPageNum();
 };
@@ -113,7 +113,7 @@ const switchImgForBtn = (switchDirection) => {
   }
 };
 
-const switchDotForBtn = (switchDirection) => {
+const changeIndicator = (switchDirection) => {
   const currentDot = document.querySelector(".is-active");
   if (currentDot[switchDirection]) {
     currentDot.classList.remove("is-active");

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -42,6 +42,7 @@ const fetcheImgData = async () => {
     const json = await response.json();
     return json.images;
   } catch (e) {
+    slideshowWrap.style.margin = 0;
     slideshowWrap.textContent = "データの取得ができませんでした。";
     console.error(e);
   } finally {
@@ -220,6 +221,7 @@ const init = async () => {
     createNumPagination();
     createIndicator();
   } else {
+    slideshowWrap.style.margin = 0;
     slideshowWrap.textContent = "データがありません。";
   }
 };

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -171,10 +171,7 @@ const createDotPagination = () => {
     dot.addEventListener(
       "click",
       (e) => {
-        switchDot(e);
-        switchImgForDot(i);
-        switchDisableForBtn();
-        getCurrentPageNum();
+        clickDotEvents(e, i);
       },
       false
     );
@@ -182,6 +179,13 @@ const createDotPagination = () => {
   }
   pagination.appendChild(fragment);
   slideshowWrap.insertAdjacentElement("afterend", pagination);
+};
+
+const clickDotEvents = (e, i) => {
+  switchDot(e);
+  switchImgForDot(i);
+  switchDisableForBtn();
+  getCurrentPageNum();
 };
 
 const switchDot = (e) => {

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -1,4 +1,4 @@
-const jsonUrl = "https://jsondata.okiba.me/v1/json/YbIZe211030061143";
+const jsonUrl = "https://myjson.dit.upm.es/api/bins/c41j";
 const slideshowWrap = document.getElementById("js-slideshow");
 const ul = document.getElementById("js-img-list");
 let images = [];

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -1,7 +1,7 @@
 const jsonUrl = "https://jsondata.okiba.me/v1/json/YbIZe211030061143";
 const slideshowWrap = document.getElementById("js-slideshow");
 const ul = document.getElementById("js-img-list");
-let imgArray = [];
+let images = [];
 
 const createElementWithClassName = (element, name) => {
   const createdElement = document.createElement(element);
@@ -122,14 +122,14 @@ const changeIndicator = (switchDirection) => {
 };
 
 const createArrayOfImgLists = () => {
-  const images = document.querySelectorAll(".slideshow__img");
-  const arrayOfImg = Array.from(images);
-  return (imgArray = arrayOfImg);
+  const imgLists = document.querySelectorAll(".slideshow__img");
+  const arrayOfImg = Array.from(imgLists);
+  return (images = arrayOfImg);
 };
 
 const getCurrentImgIndex = () => {
   const isShowImg = document.querySelector(".is-show");
-  const currentImgIndex = imgArray.indexOf(isShowImg);
+  const currentImgIndex = images.indexOf(isShowImg);
   return currentImgIndex;
 };
 
@@ -143,7 +143,7 @@ const switchDisableForBtn = () => {
     backBtn.disabled = false;
   }
 
-  if (getCurrentImgIndex() === imgArray.length - 1) {
+  if (getCurrentImgIndex() === images.length - 1) {
     nextBtn.disabled = true;
   } else {
     nextBtn.disabled = false;
@@ -158,13 +158,13 @@ const createNumPagination = () => {
 
 const getCurrentPageNum = () => {
   const pagination = document.querySelector(".number-pagination");
-  pagination.textContent = `${getCurrentImgIndex() + 1}/${imgArray.length}`;
+  pagination.textContent = `${getCurrentImgIndex() + 1}/${images.length}`;
 };
 
 const createDotPagination = () => {
   const pagination = createElementWithClassName("div", "dot-pagination");
   const fragment = document.createDocumentFragment();
-  for (let i = 0; i < imgArray.length; i++) {
+  for (let i = 0; i < images.length; i++) {
     const dot = createElementWithClassName("sapn", "dot");
     //最初のインデックスをアクティブにする
     i === 0 && dot.classList.add("is-active");
@@ -199,7 +199,7 @@ const switchImgForDot = (index) => {
   const currentImg = document.querySelector(".is-show");
   const indexOfTargetDot = index;
   currentImg.classList.remove("is-show");
-  imgArray[indexOfTargetDot].classList.add("is-show");
+  images[indexOfTargetDot].classList.add("is-show");
 };
 
 const init = async () => {


### PR DESCRIPTION
# [Lesson18](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#18)
```
スライドショーにドットのページネーションを作りましょう。
それぞれのドットではクリッカブルになっていて、押下するとその画像に切り替わります。
それとともに1/5も切り替わります。 また、3秒毎に次のスライドに自動で切り替わるauto機能を提供してください。
```
## [CodeSandbox](https://codesandbox.io/s/lesson18-create-dot-pagination-61s6i?file=/main.js)
Last commit: [b8945e5](https://github.com/yuka830/js-lessons/pull/23/commits/b8945e5bef6db0ab6a6279cdb94e65c831964492)

This time I implemented the dot pagination linked to next & back button, number pagination and images.
※ I will implement the auto function for the next PR (not now)

- Implementing dot pagination. 
I used `forEach` first but actually I use only `index` here, so I changed to `for`.

- `switchImgForbtn()` and `switchDotForbtn()` in the clickEvents function
I could've implemented them from the same function by specifying the class name and arguments about the direction, but I didn't because it would be confusing. If I create a common function, the name of it will be vague so it's going to be not clear what it works from the name. To make it easier to understand, the arguments here of `.is-show` and `.is-active` need to be renamed to be specific to image and dot, respectively, but I didn't change them because I thought these class names would be used in common.

- `switchImgForDot()`
Maybe `const indexOfTargetDot = index;` in this function is not necessary but I implemented it for easy to understand what it does.