### PR TITLE
Feat: Lesson18 (2. Create the automatic slideshow)

### DIFF
--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -166,6 +166,7 @@ const renderIndicatorForSlideshow = () => {
 
 const renderIndicator = () => {
   const pagination = createElementWithClassName("div", "indicators");
+  pagination.id = "pagination";
   const fragment = document.createDocumentFragment();
   for (let i = 0; i < images.length; i++) {
     const indicator = createElementWithClassName("span", "indicator");
@@ -183,6 +184,11 @@ const addEventToIndicator = () => {
 };
 
 const clickIndicatorEvents = (e) => {
+  const parent = document.getElementById("pagination");
+  //クリックしたのが親要素だったら何もしない
+  if (e.target === parent) {
+    return;
+  }
   stopAutoPlay();
   startAutoPlay();
   switchActiveIndicator(e);
@@ -198,19 +204,12 @@ const switchActiveIndicator = (e) => {
   targetIndicator.classList.add("is-active");
 };
 
-const isClickedTargetElement = (index) => index !== -1;
-
 const switchImgForIndicator = (e) => {
   const currentImg = document.querySelector(".is-show");
   const targetIndicator = e.target;
   const indexOfTargetIndicator = indicators.indexOf(targetIndicator);
-  //子要素indicatorをクリックしたらその要素をアクティブにし、親要素をクリックした場合はなにもしない
-  if (isClickedTargetElement(indexOfTargetIndicator)) {
-    currentImg.classList.remove("is-show");
-    images[indexOfTargetIndicator].classList.add("is-show");
-  } else {
-    return;
-  }
+  currentImg.classList.remove("is-show");
+  images[indexOfTargetIndicator].classList.add("is-show");
 };
 
 const createArrayOfIndicators = () => {

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -265,16 +265,16 @@ const init = async () => {
   } finally {
     console.log("処理が完了しました。");
   }
-  if (imgData.length !== 0) {
-    renderListsOfImg(imgData);
-    createArrayOfImgLists();
-    renderArrowBtnForSlideshow();
-    renderNumPagination();
-    renderIndicatorForSlideshow();
-    createArrayOfIndicators();
-    startAutoPlay();
-  } else {
+  if (imgData.length === 0) {
     slideshowWrap.textContent = "データがありません。";
+    return;
   }
+  renderListsOfImg(imgData);
+  createArrayOfImgLists();
+  renderArrowBtnForSlideshow();
+  renderNumPagination();
+  renderIndicatorForSlideshow();
+  createArrayOfIndicators();
+  startAutoPlay();
 };
 init();

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -192,13 +192,14 @@ const switchActiveIndicator = (e) => {
   targetIndicator.classList.add("is-active");
 };
 
+const isClickedTargetElement = (index) => index !== -1;
+
 const switchImgForIndicator = (e) => {
   const currentImg = document.querySelector(".is-show");
   const targetIndicator = e.target;
   const indexOfTargetIndicator =
     createArrayOfIndicators().indexOf(targetIndicator);
     //子要素indicatorをクリックしたらその要素をアクティブにし、親要素をクリックした場合はなにもしない
-  const isClickedTargetElement = (index) => index !== -1;
   if (isClickedTargetElement(indexOfTargetIndicator)) {
     currentImg.classList.remove("is-show");
     images[indexOfTargetIndicator].classList.add("is-show");

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -2,6 +2,8 @@ const jsonUrl = "https://myjson.dit.upm.es/api/bins/c41j";
 const slideshowWrap = document.getElementById("js-slideshow");
 const ul = document.getElementById("js-img-list");
 let images = [];
+let indicators = [];
+let autoPlay;
 
 const createElementWithClassName = (element, name) => {
   const createdElement = document.createElement(element);
@@ -93,6 +95,8 @@ const addEventToBtn = (direction, id) => {
 };
 
 const clickBtnEvents = (switchDirection) => {
+  stopAutoPlay();
+  startAutoPlay();
   switchImgForBtn(switchDirection);
   changeIndicator(switchDirection);
   switchDisableForBtn();
@@ -179,6 +183,8 @@ const addEventToIndicator = () => {
 };
 
 const clickIndicatorEvents = (e) => {
+  stopAutoPlay();
+  startAutoPlay();
   switchActiveIndicator(e);
   switchImgForIndicator(e);
   switchDisableForBtn();
@@ -197,9 +203,8 @@ const isClickedTargetElement = (index) => index !== -1;
 const switchImgForIndicator = (e) => {
   const currentImg = document.querySelector(".is-show");
   const targetIndicator = e.target;
-  const indexOfTargetIndicator =
-    createArrayOfIndicators().indexOf(targetIndicator);
-    //子要素indicatorをクリックしたらその要素をアクティブにし、親要素をクリックした場合はなにもしない
+  const indexOfTargetIndicator = indicators.indexOf(targetIndicator);
+  //子要素indicatorをクリックしたらその要素をアクティブにし、親要素をクリックした場合はなにもしない
   if (isClickedTargetElement(indexOfTargetIndicator)) {
     currentImg.classList.remove("is-show");
     images[indexOfTargetIndicator].classList.add("is-show");
@@ -211,7 +216,42 @@ const switchImgForIndicator = (e) => {
 const createArrayOfIndicators = () => {
   const indicator = document.querySelectorAll(".indicator");
   const arrayOfIndicator = Array.from(indicator);
-  return arrayOfIndicator;
+  return (indicators = arrayOfIndicator);
+};
+
+const startAutoPlay = () => {
+  autoPlay = setInterval(() => {
+    const currentImg = document.querySelector(".is-show");
+    const activeIndicator = document.querySelector(".is-active");
+    if (getCurrentImgIndex() === images.length - 1) {
+      deactivateImgAndIndicator(currentImg, activeIndicator);
+      activateFirstImgAndIndicator(images, indicators);
+    } else {
+      deactivateImgAndIndicator(currentImg, activeIndicator);
+      activateNextImgAndIndicator(currentImg, activeIndicator);
+    }
+    getCurrentPageNum();
+    switchDisableForBtn();
+  }, 3000);
+};
+
+const deactivateImgAndIndicator = (img, indicator) => {
+  img.classList.remove("is-show");
+  indicator.classList.remove("is-active");
+};
+
+const activateFirstImgAndIndicator = (images, indicators) => {
+  images[0].classList.add("is-show");
+  indicators[0].classList.add("is-active");
+};
+
+const activateNextImgAndIndicator = (img, indicator) => {
+  img.nextElementSibling.classList.add("is-show");
+  indicator.nextElementSibling.classList.add("is-active");
+};
+
+const stopAutoPlay = () => {
+  clearInterval(autoPlay);
 };
 
 const init = async () => {
@@ -231,6 +271,8 @@ const init = async () => {
     renderArrowBtnForSlideshow();
     renderNumPagination();
     renderIndicatorForSlideshow();
+    createArrayOfIndicators();
+    startAutoPlay();
   } else {
     slideshowWrap.textContent = "データがありません。";
   }


### PR DESCRIPTION
# [Lesson18](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#18)
```
スライドショーにドットのページネーションを作りましょう。
それぞれのドットではクリッカブルになっていて、押下するとその画像に切り替わります。
それとともに1/5も切り替わります。 また、3秒毎に次のスライドに自動で切り替わるauto機能を提供してください。
```
## [CodeSandbox](https://codesandbox.io/s/lesson18-create-automatic-slideshow-yqs9i?file=/main.js)
Last commit: [efbf9bd](https://github.com/yuka830/js-lessons/commit/efbf9bdb660a4236b6a154896939aeb85cc72cc2)

This is a continuation of [the previous PR](https://github.com/yuka830/js-lessons/pull/23).

I also thought about this way↓([Other CodeSandbox](https://codesandbox.io/s/lesson18-create-automatic-slideshow-forked-24sgk?file=/main.js) from line 222)
But in this way, if I click arrow button or indicators, it doesn't work well.
ex) If I click on the fourth indicator when image shows "1", that indicator goes back to second one not fifth one.
```
const startAutoPlay = () => {
  let count = 0;
  autoPlay = setInterval(() => {
    deactivateCurrentImgAndIndicator();
    if (count === images.length - 1) {
      count = 0;
      images[count].classList.add("is-show");
      indicators[count].classList.add("is-active");
    } else {
      count++;
      images[count].classList.add("is-show");
      indicators[count].classList.add("is-active");
    }
    getCurrentPageNum();
    switchDisableForBtn();
  }, 3000);
};

const deactivateCurrentImgAndIndicator = () => {
  const currentImg = document.querySelector(".is-show");
  const activeIndicator = document.querySelector(".is-active");
  currentImg.classList.remove("is-show");
  activeIndicator.classList.remove("is-active");
};
```
I could have used an `if` statement to control, but it got complicated, so I implemented it in a different way.